### PR TITLE
Fix: Prevent caching of small pages to avoid captcha loops

### DIFF
--- a/config.json
+++ b/config.json
@@ -2,5 +2,6 @@
     "additional_dates": [
         "2024-12-25",
         "2025-01-01"
-    ]
+    ],
+    "min_page_size_kb": 5
 }

--- a/scrape.py
+++ b/scrape.py
@@ -37,6 +37,13 @@ def get_current_time():
 def load_configuration(config_file='config.json'):
     with open(os.path.join(os.path.dirname(__file__), config_file), 'r') as file:
         config = json.load(file)
+    
+    # Get min_page_size_kb, defaulting to 5 if not found
+    min_page_size_kb = config.get('min_page_size_kb', 5)
+    if 'min_page_size_kb' not in config:
+        logging.warning(" 'min_page_size_kb' not found in config.json, using default value of 5KB.")
+    config['min_page_size_kb'] = min_page_size_kb  # Ensure it's in the config dict being returned
+    
     return config
 
 def is_time_to_run(config):
@@ -103,6 +110,16 @@ def fetch_webpage(url):
         raise
 
 def store_page(credential, html_content, file_name):
+    config = load_configuration()
+    min_page_size_kb = config.get('min_page_size_kb', 5) # Default to 5KB if somehow still missing
+    min_page_size_bytes = min_page_size_kb * 1024
+
+    content_size_bytes = len(html_content.encode('utf-8'))
+
+    if content_size_bytes < min_page_size_bytes:
+        logging.warning(f"Page {file_name} content size is {content_size_bytes} bytes, which is less than the minimum threshold of {min_page_size_kb}KB. Not storing.")
+        return
+
     blob_service_client = BlobServiceClient(account_url=os.getenv('AZURE_STORAGE_ACCOUNT_URL'), credential=credential)
     container_client = blob_service_client.get_container_client(os.getenv('CONTAINER'))
 


### PR DESCRIPTION
This change introduces a page size check before caching scraped content in Azure Blob Storage.

- Added `min_page_size_kb` (defaulting to 5KB) to `config.json` and updated `load_configuration` in `scrape.py` to load it.
- Modified the `store_page` function in `scrape.py` to:
    - Calculate the byte size of the fetched HTML content.
    - Compare it against the configured `min_page_size_kb`.
    - If the content is smaller than the threshold, a warning is logged, and the page is not stored. This prevents caching captcha pages or other small, unhelpful responses from the scraper.
    - Otherwise, the page is stored as usual.

This fix aims to prevent the scraper from getting stuck in loops caused by repeatedly trying to process cached captcha pages. Manual testing guidance has been provided to verify this behavior.